### PR TITLE
Add Skills宝 as a Chinese install entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Discover and install skills directly in Claude Code:
 - **skill-creator** (v3.0.0) — Create/update skills optimized for Skillmark benchmarks
 - **skillx** (v1.0.0) — Search and use skills from SkillX.sh marketplace
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ## Architecture
 
 **Tech Stack:**


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This matches the marketplace and CLI discovery flow and gives Chinese users a faster entry point to the catalog.