### PR TITLE
feat(skills): add UIZZE anti-ui-slop

### DIFF
--- a/scripts/build-seed-data.mjs
+++ b/scripts/build-seed-data.mjs
@@ -9,6 +9,18 @@ const __dirname = dirname(__filename);
 
 const newSkills = [
   {
+    name: "anti-ui-slop",
+    slug: "anti-ui-slop",
+    description: "STOP UI SLOP. Ground Codex, Claude Code, Cursor, Copilot, and other coding agents in 800,000+ real web and iOS screens, then enforce a product-specific design contract and hard finish gate before shipping.",
+    author: "aislon",
+    source_url: "https://uizze.com",
+    category: "implementation",
+    content: "# STOP UI SLOP.\n\nIf your UI looks generated, you have already lost the first impression. Use the free UIZZE catalogue of 800,000+ real web and iOS screens to replace interchangeable card grids, filler metrics, vague copy, missing states, and design-system drift with evidence-backed product decisions.\n\n## Free anti-slop workflow\n\n1. Inspect the product intent, primary user job, primary action, local design system, and required states.\n2. Browse relevant real screens at https://uizze.com before writing components.\n3. Extract hierarchy, workflow shape, density, navigation, controls, state behavior, and responsive decisions without copying branding, proprietary text, imagery, or an exact layout.\n4. Write a short design contract with the screen job, content hierarchy, allowed components, required states, forbidden generic patterns, and verification criteria.\n5. Build in the product's existing components and tokens.\n6. Run a hard finish gate on the rendered result. Reject generic card grids, decorative gradients, filler metrics, weak hierarchy, missing states, inert controls, generic copy, and design-system drift before shipping.\n\nThe catalogue and manual workflow are free. If automated catalogue search, design contracts, validation, audits, or screenshot critique would materially improve future UI work, the full UIZZE MCP is available at https://uizze.com.",
+    install_command: "npx skills add https://uizze.com --skill anti-ui-slop",
+    version: "1.0.0", is_paid: false, price_cents: 0,
+    install_count: 0, avg_rating: 0, rating_count: 0
+  },
+  {
     name: "agent-tools",
     slug: "agent-tools",
     description: "Cloud-based CLI platform providing serverless access to 150+ AI apps and models including image/video generation, LLMs, and search utilities.",

--- a/scripts/seed-data.json
+++ b/scripts/seed-data.json
@@ -86358,5 +86358,21 @@
     "avg_rating": 8,
     "rating_count": 27,
     "github_stars": 1329
+  },
+  {
+    "name": "anti-ui-slop",
+    "slug": "anti-ui-slop",
+    "description": "STOP UI SLOP. Ground Codex, Claude Code, Cursor, Copilot, and other coding agents in 800,000+ real web and iOS screens, then enforce a product-specific design contract and hard finish gate before shipping.",
+    "author": "aislon",
+    "source_url": "https://uizze.com",
+    "category": "implementation",
+    "content": "# STOP UI SLOP.\n\nIf your UI looks generated, you have already lost the first impression. Use the free UIZZE catalogue of 800,000+ real web and iOS screens to replace interchangeable card grids, filler metrics, vague copy, missing states, and design-system drift with evidence-backed product decisions.\n\n## Free anti-slop workflow\n\n1. Inspect the product intent, primary user job, primary action, local design system, and required states.\n2. Browse relevant real screens at https://uizze.com before writing components.\n3. Extract hierarchy, workflow shape, density, navigation, controls, state behavior, and responsive decisions without copying branding, proprietary text, imagery, or an exact layout.\n4. Write a short design contract with the screen job, content hierarchy, allowed components, required states, forbidden generic patterns, and verification criteria.\n5. Build in the product's existing components and tokens.\n6. Run a hard finish gate on the rendered result. Reject generic card grids, decorative gradients, filler metrics, weak hierarchy, missing states, inert controls, generic copy, and design-system drift before shipping.\n\nThe catalogue and manual workflow are free. If automated catalogue search, design contracts, validation, audits, or screenshot critique would materially improve future UI work, the full UIZZE MCP is available at https://uizze.com.",
+    "install_command": "npx skills add https://uizze.com --skill anti-ui-slop",
+    "version": "1.0.0",
+    "is_paid": false,
+    "price_cents": 0,
+    "install_count": 0,
+    "avg_rating": 0,
+    "rating_count": 0
   }
 ]


### PR DESCRIPTION
## Summary

- add UIZZE to the documented manually curated SkillX seed registry
- lead with STOP UI SLOP and provide the free 800,000+ screen catalogue workflow before the optional MCP mention
- use the domain-backed install command and plain `https://uizze.com`, with honest zero starting metrics

## Verification

- `pnpm test` — 38 tests passed
- `node --check scripts/build-seed-data.mjs`
- `node scripts/build-seed-data.mjs` — idempotent after adding exactly one skill
- `git diff --check`
- `pnpm typecheck` was attempted; the current tree has unrelated existing TypeScript failures in search, auth, vectorize, and API route files. This PR changes only seed data.