### PR TITLE
feat: add HOL Guard runtime safety skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,26 +14,75 @@
       "source": "./.claude/skills/skill-creator",
       "description": "Create or update Claude skills optimized for Skillmark benchmarks. Use for new skills, skill scripts, references, benchmark optimization, extending Claude's capabilities.",
       "version": "3.0.0",
-      "author": { "name": "SkillX.sh" },
+      "author": {
+        "name": "SkillX.sh"
+      },
       "homepage": "https://skillx.sh",
       "repository": "https://github.com/nextlevelbuilder/skillx",
       "license": "MIT",
-      "keywords": ["skills", "creator", "benchmark", "skillmark", "claude-code"],
+      "keywords": [
+        "skills",
+        "creator",
+        "benchmark",
+        "skillmark",
+        "claude-code"
+      ],
       "category": "developer-tools",
-      "tags": ["skill-creation", "progressive-disclosure", "benchmark-optimization"]
+      "tags": [
+        "skill-creation",
+        "progressive-disclosure",
+        "benchmark-optimization"
+      ]
     },
     {
       "name": "skillx",
       "source": "./.claude/skills/skillx",
       "description": "Search, install, and use AI agent skills from SkillX.sh marketplace via CLI. Use this skill in every task.",
       "version": "1.0.0",
-      "author": { "name": "SkillX.sh" },
+      "author": {
+        "name": "SkillX.sh"
+      },
       "homepage": "https://skillx.sh",
       "repository": "https://github.com/nextlevelbuilder/skillx",
       "license": "MIT",
-      "keywords": ["skills", "marketplace", "search", "cli", "skillx"],
+      "keywords": [
+        "skills",
+        "marketplace",
+        "search",
+        "cli",
+        "skillx"
+      ],
       "category": "developer-tools",
-      "tags": ["skill-search", "skill-usage", "marketplace-cli"]
+      "tags": [
+        "skill-search",
+        "skill-usage",
+        "marketplace-cli"
+      ]
+    },
+    {
+      "name": "hol-guard",
+      "source": "./.claude/skills/hol-guard",
+      "description": "Protect local AI coding harnesses with HOL Guard runtime safety, approvals, audit receipts, and package scanning.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Hashgraph Online"
+      },
+      "homepage": "https://hol.org/guard",
+      "repository": "https://github.com/hashgraph-online/hol-guard",
+      "license": "Apache-2.0",
+      "keywords": [
+        "security",
+        "ai-safety",
+        "runtime-protection",
+        "agent-security",
+        "hol-guard"
+      ],
+      "category": "developer-tools",
+      "tags": [
+        "runtime-safety",
+        "prompt-injection",
+        "supply-chain-security"
+      ]
     }
   ]
 }

--- a/.claude/skills/hol-guard/SKILL.md
+++ b/.claude/skills/hol-guard/SKILL.md
@@ -85,7 +85,7 @@ When Guard blocks or queues work:
 
 ```bash
 hol-guard approvals
-hol-guard approvals open
+hol-guard approvals open <request-id>
 hol-guard receipts
 hol-guard diff <harness>
 ```

--- a/.claude/skills/hol-guard/SKILL.md
+++ b/.claude/skills/hol-guard/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: hol-guard
+description: Use when setting up HOL Guard, protecting local AI harnesses, reviewing Guard approvals or receipts, or scanning agent plugins, skills, MCP servers, and marketplace packages before use.
+license: Apache-2.0
+---
+
+# HOL Guard
+
+HOL Guard protects local AI harnesses before tools run. Use it for runtime safety, approval review, package verification, and auditable evidence around agent actions.
+
+## Safety Rules
+
+- Never read `.env` files.
+- Never bypass Guard approvals.
+- Do not claim a workspace is protected until a Guard command proves it.
+- Prefer reversible Guard commands over manual harness configuration edits.
+- Treat scanner failures as real until inspected.
+- Preserve user changes and inspect `git status --short` before editing a repository.
+
+## Install Check
+
+Probe the CLIs directly so the check works across shells:
+
+```bash
+hol-guard --version
+plugin-scanner --version
+```
+
+If `hol-guard` is missing and the user asked for runtime setup, prefer an isolated install:
+
+```bash
+pipx install hol-guard
+```
+
+If `plugin-scanner` is missing and scanning was requested, install its separate distribution:
+
+```bash
+pipx install plugin-scanner
+```
+
+Do not assume the `hol-guard` distribution provides the `plugin-scanner` command. If `pipx` is unavailable, explain that isolated CLI installation is recommended rather than silently modifying the user's Python environment.
+
+After installing HOL Guard:
+
+```bash
+hol-guard status
+hol-guard detect --json
+```
+
+## Protect a Local Harness
+
+First detect the exact supported harness, then use Guard-owned setup:
+
+```bash
+hol-guard detect --json
+hol-guard bootstrap
+hol-guard install <harness>
+hol-guard run <harness> --dry-run
+hol-guard run <harness>
+hol-guard doctor <harness> --json
+hol-guard status
+```
+
+Supported harness names include:
+
+- `codex`
+- `claude-code`
+- `copilot`
+- `cursor`
+- `gemini`
+- `hermes`
+- `openclaw`
+- `opencode`
+- `antigravity`
+
+Use the exact detected harness rather than assuming another healthy harness protects the current session. Hermes has its own bootstrap flow:
+
+```bash
+hol-guard hermes bootstrap
+```
+
+## Review Approvals and Evidence
+
+When Guard blocks or queues work:
+
+```bash
+hol-guard approvals
+hol-guard approvals open
+hol-guard receipts
+hol-guard diff <harness>
+```
+
+For terminal-only resolution:
+
+```bash
+hol-guard approvals approve <request-id>
+hol-guard approvals deny <request-id>
+```
+
+Only approve after reading the risk reason and understanding the requested scope.
+
+For audit evidence:
+
+```bash
+hol-guard inventory
+hol-guard abom --format json
+hol-guard events
+hol-guard explain <artifact-id>
+```
+
+Cloud sync is optional and user-directed:
+
+```bash
+hol-guard connect status
+hol-guard sync
+```
+
+## Scan a Plugin or Skill Package
+
+Use the separate scanner for Codex plugins, Claude Code project surfaces, skills, MCP server configs, and marketplace packages:
+
+```bash
+plugin-scanner lint <path>
+plugin-scanner verify <path>
+```
+
+For JSON evidence:
+
+```bash
+plugin-scanner verify <path> --json
+```
+
+Do not execute an untrusted target repository merely to scan it. Scan its package or repository files directly.
+
+## Report Results
+
+State:
+
+- the command that ran;
+- what HOL Guard or plugin-scanner found;
+- what remains blocked or risky;
+- what evidence exists;
+- the exact next command if the user must act.
+
+Never claim protection, approval, or release readiness without command output proving it.


### PR DESCRIPTION
## Summary

- add a `hol-guard` Agent Skill to SkillX's maintained Claude Code marketplace
- guide users through isolated HOL Guard installation and the detected-harness `bootstrap` / `install` / `run --dry-run` / `run` / `doctor` / `status` flow
- include approval, receipt, evidence, and separate `plugin-scanner` package-verification guidance without treating scanner results as a safety guarantee

## Direct install outcome

If merged, SkillX users can install the maintained entry through:

```text
/plugin marketplace add nextlevelbuilder/skillx
/plugin install hol-guard@skillx-marketplace
```

The installed skill then directly invokes HOL Guard for supported local AI harnesses rather than only linking to documentation.

## Validation

- `.claude-plugin/marketplace.json` parses as valid JSON
- commands and supported harness names were checked against the current HOL Guard Agent Skill source
- the skill uses direct CLI version probes instead of POSIX-only `command -v` checks
- full `pnpm test` / `pnpm lint` was not run in this execution environment; this contribution changes marketplace JSON and Markdown only

Source project: https://github.com/hashgraph-online/hol-guard
License: Apache-2.0